### PR TITLE
#19 - dockerfile for etl 

### DIFF
--- a/pipeline/etl.dockerfile
+++ b/pipeline/etl.dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12
+
+COPY requirements.txt .
+
+RUN pip3 install -r requirements.txt
+
+COPY connect_to_database.py .
+COPY email_notifier.py .
+COPY extract.py .
+COPY transform.py .
+COPY load.py .
+COPY etl.py .
+
+CMD ["python3","etl.py"]
+
+# docker build -t price_slash_test -f etl.dockerfile .
+# docker run -p 5432:5432 --env-file .env price_slash_test

--- a/pipeline/etl.dockerfile
+++ b/pipeline/etl.dockerfile
@@ -12,6 +12,3 @@ COPY load.py .
 COPY etl.py .
 
 CMD ["python3","etl.py"]
-
-# docker build -t price_slash_test -f etl.dockerfile .
-# docker run -p 5432:5432 --env-file .env price_slash_test

--- a/test_database.sql
+++ b/test_database.sql
@@ -30,10 +30,9 @@ VALUES
     ('Headphones', 'https://www.bestbuy.com/headphones', 3, 199.99),
     ('Tablet', 'https://www.walmart.com/tablet', 4, 299.99),
     ('Smartwatch', 'https://www.target.com/smartwatch', 5, 149.99),
-    ('Slay the Spire', 'https://store.steampowered.com/app/646570/Slay_the_Spire/', 6, 19.99);
-
-    -- ('Cyberpunk 2077','https://store.steampowered.com/app/1091500/Cyberpunk_2077/',6,49.99),
-    -- ('Stardew Valley','https://store.steampowered.com/app/413150/Stardew_Valley/',6,10.99);
+    ('Slay the Spire', 'https://store.steampowered.com/app/646570/Slay_the_Spire/', 6, 19.99),
+    ('Cyberpunk 2077','https://store.steampowered.com/app/1091500/Cyberpunk_2077/',6,49.99),
+    ('Stardew Valley','https://store.steampowered.com/app/413150/Stardew_Valley/',6,10.99);
 
 INSERT INTO price_changes (price, product_id, timestamp)
 VALUES 


### PR DESCRIPTION
This dockerises the ETL pipeline which includes `extract.py`, `transform.py`, `load.py` and `email_notifier.py` which is combined in `etl.py`. Currently works locally.
- Build: `docker build -t price_slash_test -f etl.dockerfile .`
- Run and test localy: `docker run -p 5432:5432 --env-file .env price_slash_test`

need to remove the comments for these commands in the file and extract.py needs to be fixed before this is merged.

This closes #19 