### PR TITLE
#40 terraform script for streamlit dashboard

### DIFF
--- a/pipeline/etl_docker_push.sh
+++ b/pipeline/etl_docker_push.sh
@@ -1,0 +1,7 @@
+aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin 129033205317.dkr.ecr.eu-west-2.amazonaws.com
+
+docker build --platform linux/amd64 -f etl.dockerfile -t c14-priceslashers-etl-ecr .
+
+docker tag c14-priceslashers-etl-ecr:latest 129033205317.dkr.ecr.eu-west-2.amazonaws.com/c14-priceslashers-etl-ecr:latest
+
+docker push 129033205317.dkr.ecr.eu-west-2.amazonaws.com/c14-priceslashers-etl-ecr:latest

--- a/terraform/terraform-dashboard-ecr/main.tf
+++ b/terraform/terraform-dashboard-ecr/main.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  region = "eu-west-2"
+}
+
+
+resource "aws_ecr_repository" "ecr_for_dashboard" {
+  name                 = var.DASHBOARD_ECR_NAME
+  image_tag_mutability = "MUTABLE"  
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+  force_delete = true
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}

--- a/terraform/terraform-dashboard-ecr/variables.tf
+++ b/terraform/terraform-dashboard-ecr/variables.tf
@@ -1,0 +1,4 @@
+variable DASHBOARD_ECR_NAME {
+    type = string
+    description = "ECR name for Streamlit Dashboard"
+}

--- a/terraform/terraform-dashboard-ecs/main.tf
+++ b/terraform/terraform-dashboard-ecs/main.tf
@@ -1,0 +1,127 @@
+data "aws_ecs_cluster" "c14-cluster" {
+    cluster_name = "c14-ecs-cluster"
+}
+
+data "aws_iam_role" "execution-role" {
+    name = "ecsTaskExecutionRole"
+}
+
+data "aws_vpc" "c14-vpc" {
+    id = "vpc-0344763624ac09cb6"
+}
+
+data "aws_subnet" "c14-subnet-1" {
+  id = "subnet-0497831b67192adc2"
+}
+
+data "aws_subnet" "c14-subnet-2" {
+  id = "subnet-0acda1bd2efbf3922"
+}
+
+data "aws_subnet" "c14-subnet-3" {
+  id = "subnet-0465f224c7432a02e"
+}
+
+
+
+resource "aws_ecs_task_definition" "c14-price-slash-dashboard-task-def" {
+  family                   = "c14-price-slash-dashboard-task-def"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  execution_role_arn       = data.aws_iam_role.execution-role.arn
+  cpu                      = 1024
+  memory                   = 2048
+  container_definitions    = jsonencode([
+    {
+      name         = "c14-price-slash-dashboard-task-def"
+      image        = var.DASHBOARD_ECR_URL
+      cpu          = 10
+      memory       = 512
+      essential    = true
+      portMappings = [
+        {
+            containerPort = 80
+            hostPort      = 80
+        },
+        {
+            containerPort = 8501
+            hostPort      = 8501       
+        }
+      ]
+      environment= [
+                {
+                    "name": "ACCESS_KEY",
+                    "value": var.AWS_ACCESS_KEY
+                },
+                {
+                    "name": "SECRET_ACCESS_KEY",
+                    "value": var.AWS_SECRET_KEY
+                },
+                {
+                    "name": "DB_NAME",
+                    "value": var.DB_NAME
+                },
+                {
+                    "name": "DB_USER",
+                    "value": var.DB_USER
+                },
+                {
+                    "name": "DB_PASSWORD",
+                    "value": var.DB_PASSWORD
+                },
+                {
+                    "name": "DB_HOST",
+                    "value": var.DB_HOST
+                },
+                {
+                    "name": "DB_PORT",
+                    "value": var.DB_PORT
+                }
+            ]
+            logConfiguration = {
+                logDriver = "awslogs"
+                options = {
+                    "awslogs-create-group"  = "true"
+                    "awslogs-group"         = "/ecs/c14-price-slash-dashboard-task-def"
+                    "awslogs-region"        = "eu-west-2"
+                    "awslogs-stream-prefix" = "ecs"
+                }
+            }
+    },
+  ])
+}
+
+resource "aws_security_group" "c14-price-slash-dashboard-sg" {
+    name        = "c14-price-slash-dashboard-sg"
+    description = "Security group for connecting to dashboard"
+    vpc_id      = data.aws_vpc.c14-vpc.id
+
+    egress {
+        from_port   = 0
+        to_port     = 0
+        protocol    = "-1"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+    ingress {
+        from_port   = 8501
+        to_port     = 8501
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+
+}
+
+resource "aws_ecs_service" "c14-price-slash-dashboard-service-tf" {
+    name            = "c14-price-slash-dashboard-service-tf"
+    cluster         = data.aws_ecs_cluster.c14-cluster
+    task_definition = aws_ecs_task_definition.c14-price-slash-dashboard-task-def.arn
+    desired_count   = 1
+    launch_type     = "FARGATE" 
+    
+    network_configuration {
+        subnets          = [data.aws_subnet.c14-subnet-1.id, data.aws_subnet.c14-subnet-2.id, data.aws_subnet.c14-subnet-3.id] 
+        security_groups  = [aws_security_group.c14-price-slash-dashboard-sg.id] 
+        assign_public_ip = true
+    }
+}

--- a/terraform/terraform-dashboard-ecs/main.tf
+++ b/terraform/terraform-dashboard-ecs/main.tf
@@ -22,6 +22,10 @@ data "aws_subnet" "c14-subnet-3" {
   id = "subnet-0465f224c7432a02e"
 }
 
+data "aws_ecr_repository" "ecr_for_dashboard" {
+    name = var.DASHBOARD_ECR_NAME
+}
+
 
 
 resource "aws_ecs_task_definition" "c14-price-slash-dashboard-task-def" {
@@ -34,7 +38,7 @@ resource "aws_ecs_task_definition" "c14-price-slash-dashboard-task-def" {
   container_definitions    = jsonencode([
     {
       name         = "c14-price-slash-dashboard-task-def"
-      image        = var.DASHBOARD_ECR_URL
+      image        = data.aws_ecr_repository.ecr_for_dashboard.repository_url
       cpu          = 10
       memory       = 512
       essential    = true

--- a/terraform/terraform-dashboard-ecs/variables.tf
+++ b/terraform/terraform-dashboard-ecs/variables.tf
@@ -1,0 +1,28 @@
+variable "AWS_ACCESS_KEY" {
+  type = string
+}
+variable "AWS_SECRET_KEY" {
+  type = string
+}
+
+
+variable "DB_USER" {
+    type = string
+}
+variable "DB_PASSWORD"{
+    type = string
+}
+variable "DB_NAME" {
+    type = string
+}
+variable "DB_HOST"{
+    type = string
+}
+variable "DB_PORT"{
+    type = string
+}
+
+
+variable "DASHBOARD_ECR_URL"{
+    type = string
+}

--- a/terraform/terraform-dashboard-ecs/variables.tf
+++ b/terraform/terraform-dashboard-ecs/variables.tf
@@ -23,6 +23,7 @@ variable "DB_PORT"{
 }
 
 
-variable "DASHBOARD_ECR_URL"{
+variable "DASHBOARD_ECR_NAME"{
     type = string
+    description = "ECR that holds the Dashboard."
 }


### PR DESCRIPTION
Closes: [Issue 40](https://github.com/users/gem09lo/projects/1/views/1?pane=issue&itemId=89685545&issue=gem09lo%7CPriceSlashTrack%7C40).

## Outcome:
- An ECR is created in a separate terraform folder for the dashboard. Once the ECR is created, an image can be added into the ECR (dashboard image).
- Then in a second terraform folder for the dashboard is the contents of a Task Definition based off of the image and the creation of an AWS ECS Service which will run the dashboard.