### PR TITLE
Adding time filtering to charts on dashboard.

### DIFF
--- a/streamlit_dashboard/dashboard.py
+++ b/streamlit_dashboard/dashboard.py
@@ -335,7 +335,6 @@ def display_charts(product_id) -> alt.Chart:
         filtered_df = df[df["Date"] >= (
             current_time - time_ranges[time_range])].copy()
 
-        # Include day, hour, and minute for this time range
         filtered_df.loc[:, 'FormattedDate'] = filtered_df['Date'].dt.strftime(
             '%Y-%m-%d %H:%M:%S')
 

--- a/streamlit_dashboard/dashboard.py
+++ b/streamlit_dashboard/dashboard.py
@@ -341,7 +341,6 @@ def display_charts(product_id) -> alt.Chart:
         st.warning("No price data available for the selected time range.")
         return None
 
-    # Create the Altair chart
     chart = alt.Chart(filtered_df).mark_line().encode(
         x=alt.X('FormattedDate:N',
                 title='Timestamp',

--- a/streamlit_dashboard/dashboard.py
+++ b/streamlit_dashboard/dashboard.py
@@ -310,7 +310,6 @@ def display_charts(product_id) -> alt.Chart:
 
     df = pd.DataFrame(result, columns=['Price', 'Date'])
 
-    # Ensure timestamps are parsed correctly and in UTC
     df['Date'] = pd.to_datetime(df['Date'], utc=True)
 
     current_time = pd.Timestamp.now(tz='UTC')

--- a/streamlit_dashboard/dashboard.py
+++ b/streamlit_dashboard/dashboard.py
@@ -330,7 +330,7 @@ def display_charts(product_id) -> alt.Chart:
 
         filtered_df.loc[:, 'FormattedDate'] = filtered_df['Date'].dt.strftime(
             '%H:%M')
-    else:  # "Last 3 Days"
+    else:
         filtered_df = df[df["Date"] >= (
             current_time - time_ranges[time_range])].copy()
 

--- a/streamlit_dashboard/dashboard.py
+++ b/streamlit_dashboard/dashboard.py
@@ -329,7 +329,6 @@ def display_charts(product_id) -> alt.Chart:
         filtered_df = df[df['Date'] >= (
             most_recent_timestamp - time_ranges[time_range])].copy()
 
-        # Use hour and minute for these time ranges
         filtered_df.loc[:, 'FormattedDate'] = filtered_df['Date'].dt.strftime(
             '%H:%M')
     else:  # "Last 3 Days"

--- a/streamlit_dashboard/dashboard.py
+++ b/streamlit_dashboard/dashboard.py
@@ -325,7 +325,6 @@ def display_charts(product_id) -> alt.Chart:
 
     most_recent_timestamp = df['Date'].max()
 
-    # Filter data based on the selected time range
     if time_range == "Last 30 Minutes" or time_range == "Last 24 Hours":
         filtered_df = df[df['Date'] >= (
             most_recent_timestamp - time_ranges[time_range])].copy()

--- a/streamlit_dashboard/database_connection.py
+++ b/streamlit_dashboard/database_connection.py
@@ -5,6 +5,9 @@ from dotenv import load_dotenv
 import psycopg2
 
 
+load_dotenv()
+
+
 def get_connection():
     """Gets connection to the database"""
     try:
@@ -33,5 +36,4 @@ def get_cursor(conn):
 
 
 if __name__ == "__main__":
-    load_dotenv()
     print(get_connection())


### PR DESCRIPTION
- Updated `dashboard.py` to include time filtering (last 30 minutes, last 24 hours, last 3 days)
- Fixed bug in `database_connections.py` by moving `load_dotenv()` out of the `if __name__ == "__main__"` block

This closes #123 